### PR TITLE
Remove events from pickle cache

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,11 @@ ciso8601>=1.0.1
 isort>=5.10.1
 flake8>=4.0.1
 flake8-docstrings>=1.6.0
+freezegun==1.3.1
 mypy>=0.910
 pylint>=2.12.1
 pytest-cov>=3.0.0
 pytest-asyncio>=0.16.0
+pytest-freezer>=0.4.8
 pytest>=6.2.4
 types-aiofiles>=0.8.3

--- a/tests/fixtures/activities.json
+++ b/tests/fixtures/activities.json
@@ -10,8 +10,8 @@
     "createdAt": "2020-03-30T12:35:02.204Z",
     "updatedAt": "2020-03-30T12:35:02.566Z",
     "id": "1234567890ab1234567890ab",
-    "media": "https://skybell-thumbnails-stage.s3.amazonaws.com/012345670123456789abcdef/1646859244793-951012345670123456789abcdef_012345670123456789abcdef.jpeg",
-    "mediaSmall": "https://skybell-thumbnails-stage.s3.amazonaws.com/012345670123456789abcdef/1646859244793-951012345670123456789abcdef_012345670123456789abcdef_small.jpeg"
+    "media": "https://skybell-thumbnails-stage.s3.amazonaws.com/012345670123456789abcdef/1646859244793-951012345670123456789abcdef_012345670123456789abcdef.jpeg?Expires=1585575303",
+    "mediaSmall": "https://skybell-thumbnails-stage.s3.amazonaws.com/012345670123456789abcdef/1646859244793-951012345670123456789abcdef_012345670123456789abcdef_small.jpeg?Expires=1585575303"
   },
   {
     "videoState": "download:ready",
@@ -24,7 +24,7 @@
     "createdAt": "2020-03-30T11:35:02.204Z",
     "updatedAt": "2020-03-30T11:35:02.566Z",
     "id": "1234567890ab1234567890a9",
-    "media": "https://skybell-thumbnails-stage.s3.amazonaws.com/012345670123456789abcdef/1646859244793-951012345670123456789abcdef_012345670123456789abcde9.jpeg",
-    "mediaSmall": "https://skybell-thumbnails-stage.s3.amazonaws.com/012345670123456789abcdef/1646859244793-951012345670123456789abcdef_012345670123456789abcde9_small.jpeg"
+    "media": "https://skybell-thumbnails-stage.s3.amazonaws.com/012345670123456789abcdef/1646859244793-951012345670123456789abcdef_012345670123456789abcde9.jpeg?Expires=1585575303",
+    "mediaSmall": "https://skybell-thumbnails-stage.s3.amazonaws.com/012345670123456789abcdef/1646859244793-951012345670123456789abcdef_012345670123456789abcde9_small.jpeg?Expires=1585575303"
   }
 ]

--- a/tests/fixtures/new-activity.json
+++ b/tests/fixtures/new-activity.json
@@ -10,7 +10,7 @@
     "createdAt": "2020-03-30T13:30:02.204Z",
     "updatedAt": "2020-03-30T13:30:02.566Z",
     "id": "1234567890ab1234567890ac",
-    "media": "https://skybell-thumbnails-stage.s3.amazonaws.com/012345670123456789abcdef/1646859244794-951012345670123456789abcdef_012345670123456789abcdef.jpeg",
-    "mediaSmall": "https://skybell-thumbnails-stage.s3.amazonaws.com/012345670123456789abcdef/1646859244794-951012345670123456789abcdef_012345670123456789abcdef_small.jpeg"
+    "media": "https://skybell-thumbnails-stage.s3.amazonaws.com/012345670123456789abcdef/1646859244794-951012345670123456789abcdef_012345670123456789abcdef.jpeg?Expires=1585575303",
+    "mediaSmall": "https://skybell-thumbnails-stage.s3.amazonaws.com/012345670123456789abcdef/1646859244794-951012345670123456789abcdef_012345670123456789abcdef_small.jpeg?Expires=1585575303"
   }
 ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Events were being saved to the pickle cache. This resulted in queries to S3 with expired credentials when there is no recordings available to get from AWS to replace the "current" event. Events are no longer saved to the pickle cache and are instead stored in memory.

## Type of change

<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted (`make lint`)
- [x] Tests have been added to verify that the new code works.
